### PR TITLE
Add a shortcut to open the popup window

### DIFF
--- a/source/_locales/en/messages.json
+++ b/source/_locales/en/messages.json
@@ -134,6 +134,11 @@
     "description": "Notifications checkbox description enabled"
   },
 
+  "optionsListOpen": {
+    "message": "Open the popup window:",
+    "description": "Open the popup window"
+  },
+
   "optionsListPlay": {
     "message": "Play or pause:",
     "description": "Play or pause"

--- a/source/_locales/ru/messages.json
+++ b/source/_locales/ru/messages.json
@@ -135,6 +135,11 @@
     "description": "Notifications checkbox description enabled"
   },
 
+  "optionsListOpen": {
+    "message": "Открыть всплывающее окно:",
+    "description": "Open the popup window"
+  },
+
   "optionsListPlay": {
     "message": "Проигрывание или пауза:",
     "description": "Play or pause"

--- a/source/manifest.json
+++ b/source/manifest.json
@@ -26,6 +26,12 @@
     ]
   },
   "commands": {
+    "_execute_browser_action": {
+      "suggested_key": {
+        "default": "Alt+Z"
+      },
+      "description": "Open the popup window"
+    },
     "next": {
       "suggested_key": {
         "default": "Ctrl+Shift+L"

--- a/source/options.html
+++ b/source/options.html
@@ -84,6 +84,13 @@
 
       <div class="options__list">
         <div>
+          <label class="options__label" for="_execute_browser_action">
+            <span data-i18n="optionsListOpen"></span>
+          </label>
+          <input class="option__input" type="text" name="_execute_browser_action" id="_execute_browser_action"
+            autocomplete="off" placeholder="Ctrl + Shift + Y" />
+        </div>
+        <div>
           <label class="options__label" for="play">
             <span data-i18n="optionsListPlay"></span>
           </label>


### PR DESCRIPTION
When I listen to some new music, I often open the popup to see what's playing. It's easier with a shortcut!

I chose `Alt + Z` mainly because the keys are close to each other, and it's free with my set of extensions.

This will work especially well if we make the popup accept normal one-key shortcuts (see #2).