### PR TITLE
Native Yandex.Music shortcuts in the popup window

### DIFF
--- a/source/controls-backend.js
+++ b/source/controls-backend.js
@@ -66,6 +66,28 @@ chrome.runtime.onMessage.addListener(response => {
   updatePopup(response)
 })
 
+/* Listen to keypresses in the popup like in the player tab: */
+/* TODO: handle Mute (key 0) */
+document.addEventListener('keydown', (e) => {
+  let action
+  if (e.code === 'Space' || e.code === 'KeyP')
+    action = 'play'
+  else if (e.code === 'KeyL')
+    action = 'next'
+  else if (e.code === 'KeyK')
+    action = 'prev'
+  else if (e.code === 'KeyF')
+    action = 'liked'
+  else if (e.code === 'KeyD')
+    action = 'disliked'
+  else if (e.key === '+')
+    action = 'volumeUp'
+  else if (e.key === '-')
+    action = 'volumeDown'
+  if (action)
+    chrome.tabs.sendMessage(state.yandexTabID, { action, isPopupAction: true })
+})
+
 /* Get Music state if possible: */
 let checkMusicState = () => {
   if (bg && bg.yandexTabID && bg.yandexTabID.length > 0) {

--- a/source/controls-backend.js
+++ b/source/controls-backend.js
@@ -70,20 +70,28 @@ chrome.runtime.onMessage.addListener(response => {
 /* TODO: handle Mute (key 0) */
 document.addEventListener('keydown', (e) => {
   let action
-  if (e.code === 'Space' || e.code === 'KeyP')
-    action = 'play'
-  else if (e.code === 'KeyL')
-    action = 'next'
-  else if (e.code === 'KeyK')
-    action = 'prev'
-  else if (e.code === 'KeyF')
-    action = 'liked'
-  else if (e.code === 'KeyD')
-    action = 'disliked'
-  else if (e.key === '+')
+  if (e.altKey || e.ctrlKey || e.metaKey)
+    return
+  if (e.key === '+')
     action = 'volumeUp'
   else if (e.key === '-')
     action = 'volumeDown'
+  else {
+    // Volume Up/Down (handled above) can be repeated, and Shift may be used to enter "+",
+    // so these are only checked here
+    if (e.repeat || e.shiftKey)
+      return
+    if (e.code === 'Space' || e.code === 'KeyP')
+      action = 'play'
+    else if (e.code === 'KeyL')
+      action = 'next'
+    else if (e.code === 'KeyK')
+      action = 'prev'
+    else if (e.code === 'KeyF')
+      action = 'liked'
+    else if (e.code === 'KeyD')
+      action = 'disliked'
+  }
   if (action)
     chrome.tabs.sendMessage(state.yandexTabID, { action, isPopupAction: true })
 })


### PR DESCRIPTION
It will be nice to use Space for play/pause, K/L for prev/next, etc., when the popup window is active. A few other shortcuts are listed in [the help](https://yandex.ru/support/music/users/listening.html#hotkeys).

I've tried to handle most corner cases, like zooming in/out with `Ctrl + -/+` while the popup is open, which could also be treated as volume up/down. I've only tested it on Windows, though.